### PR TITLE
feat: adjust background opacity without changing font opacity

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# v0.1.9 `20/01/2022`
+## Improvement
++ Embedded Player
++ + Opacity of caption text and background now can be set separately. (Thanks @Axton)
+
 # v0.1.8 `03/01/2022`
 ## Add Features
 + Embedded Player

--- a/html/settings.html
+++ b/html/settings.html
@@ -73,9 +73,10 @@
             <div>Caption Style</div>
             <div class="row"><label>Font Family:</label><input type="text"></div>
             <div class="row"><label>Font Size:</label><input type="number" min="10" max="300">%</div>
-            <div class="row"><label>Font Color:</label><input type="color"></div>
+            <div class="row"><label>Text Color:</label><input type="color"></div>
+            <div class="row"><label>Text Opacity:</label><input type="number" min="0" max="100">%</div>
             <div class="row"><label>Background Color:</label><input type="color"></div>
-            <div class="row"><label>Opacity:</label><input type="number" min="0" max="100">%</div>
+            <div class="row"><label>Background Opacity:</label><input type="number" min="0" max="100">%</div>
             <div class="btns-bar">
                 <button>Default</button>
                 <button>Save</button>

--- a/js/background.js
+++ b/js/background.js
@@ -6,7 +6,17 @@ chrome.runtime.onInstalled.addListener(() => {
         if (!items.liveSessions) ini_conf.liveSessions = JSON.stringify([]);
         if (!items.collapsedPortlets) ini_conf.collapsedPortlets = JSON.stringify([]);
         if (!items.autoLogin) ini_conf.autoLogin = JSON.stringify({ enabled: false, username: '', password: '' });
-        if (!items.playerSettings) ini_conf.playerSettings = JSON.stringify({ fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', opacity: '100' });
+        if (!items.playerSettings) ini_conf.playerSettings = JSON.stringify({ fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', textOpacity: '100', bgOpacity: '80' });
+        // update from v0.1.8 to v0.1.9
+        else {
+            let oldPlayerSettings = JSON.parse(items.playerSettings);
+            if (oldPlayerSettings.opacity !== undefined) {
+                delete oldPlayerSettings.opacity;
+                oldPlayerSettings.textOpacity = '100';
+                oldPlayerSettings.bgOpacity = '80';
+                ini_conf.playerSettings = JSON.stringify(oldPlayerSettings);
+            }
+        }
         chrome.storage.sync.set(ini_conf);
     });
 

--- a/js/player.js
+++ b/js/player.js
@@ -23,7 +23,7 @@ function readableTimeToSeconds(time) {
 }
 
 function hex2Rgb(hex) {
-    return `${parseInt(hex.substr(1, 2), 16)}, ${parseInt(hex.substr(3, 2), 16)}, ${parseInt(hex.substr(5, 2), 16)}`;
+    return `${parseInt(hex.substr(1, 2), 16)},${parseInt(hex.substr(3, 2), 16)},${parseInt(hex.substr(5, 2), 16)}`;
 }
 
 let MouseEventCreator = {
@@ -110,10 +110,10 @@ let EmbeddedVideoController = {
             let newStyle = document.createElement('style');
             newStyle.setAttribute('type', 'text/css');
             let captionCSS = 'div.vjs-text-track-display>div>div>div{';
-            captionCSS += `font-family: ${player_settings.fontFamily}!important;`;
-            captionCSS += `font-size: ${(parseInt(player_settings.fontSize) / 100) * 2.5}vw !important;`;
-            captionCSS += `color: ${player_settings.fontColor}!important;`;
-            captionCSS += `background-color: rgba(${hex2Rgb(player_settings.bgColor)}, ${parseInt(player_settings.opacity) / 100})!important;`;
+            captionCSS += `font-family:${player_settings.fontFamily} !important;`;
+            captionCSS += `font-size:${(parseInt(player_settings.fontSize) / 100) * 2.5}vw !important;`;
+            captionCSS += `color:rgba(${hex2Rgb(player_settings.fontColor)},${parseInt(player_settings.textOpacity) / 100}) !important;`;
+            captionCSS += `background-color:rgba(${hex2Rgb(player_settings.bgColor)},${parseInt(player_settings.bgOpacity) / 100}) !important;`;
             captionCSS += '}';
             newStyle.innerHTML = captionCSS;
             document.head.appendChild(newStyle);

--- a/js/player.js
+++ b/js/player.js
@@ -22,6 +22,10 @@ function readableTimeToSeconds(time) {
     return secs;
 }
 
+function hex2Rgb(hex) {
+    return `${parseInt(hex.substr(1, 2), 16)}, ${parseInt(hex.substr(3, 2), 16)}, ${parseInt(hex.substr(5, 2), 16)}`;
+}
+
 let MouseEventCreator = {
     // create a mouse event
     click() {
@@ -106,11 +110,10 @@ let EmbeddedVideoController = {
             let newStyle = document.createElement('style');
             newStyle.setAttribute('type', 'text/css');
             let captionCSS = 'div.vjs-text-track-display>div>div>div{';
-            captionCSS += 'font-family:' + player_settings.fontFamily + ' !important;';
-            captionCSS += 'font-size:' + ((parseInt(player_settings.fontSize) / 100) * 2.5) + 'vw !important;';
-            captionCSS += 'color:' + player_settings.fontColor + ' !important;';
-            captionCSS += 'background-color:' + player_settings.bgColor + ' !important;';
-            captionCSS += 'opacity:' + (parseInt(player_settings.opacity) / 100) + ' !important;';
+            captionCSS += `font-family: ${player_settings.fontFamily}!important;`;
+            captionCSS += `font-size: ${(parseInt(player_settings.fontSize) / 100) * 2.5}vw !important;`;
+            captionCSS += `color: ${player_settings.fontColor}!important;`;
+            captionCSS += `background-color: rgba(${hex2Rgb(player_settings.bgColor)}, ${parseInt(player_settings.opacity) / 100})!important;`;
             captionCSS += '}';
             newStyle.innerHTML = captionCSS;
             document.head.appendChild(newStyle);

--- a/js/settings.js
+++ b/js/settings.js
@@ -151,8 +151,10 @@ let PageManager = {
                     items.playerSettings.fontColor = '#ffffff';
                 if (typeof items.playerSettings.bgColor !== 'string')
                     items.playerSettings.bgColor = '#000000';
-                if (typeof items.playerSettings.opacity !== 'string')
-                    items.playerSettings.opacity = '100';
+                if (typeof items.playerSettings.textOpacity !== 'string')
+                    items.playerSettings.textOpacity = '100';
+                if (typeof items.playerSettings.bgOpacity !== 'string')
+                    items.playerSettings.bgOpacity = '80';
                 user_conf.playerSettings = JSON.stringify(items.playerSettings);
             }
 
@@ -186,7 +188,7 @@ let PageManager = {
                 liveSessions: JSON.stringify([]),
                 collapsedPortlets: JSON.stringify([]),
                 autoLogin: JSON.stringify({ enabled: false, username: '', password: '' }),
-                playerSettings: JSON.stringify({ fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', opacity: '100' })
+                playerSettings: JSON.stringify({ fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', textOpacity: '100', bgOpacity: '80' })
             };
             chrome.storage.sync.set(ini_conf, () => {
                 reset_btn.innerText = 'Reset';
@@ -253,14 +255,16 @@ let PageManager = {
                 let msg = document.querySelector('#player-settings-page div:last-child');
                 let font_family_in = inputs[0];
                 let font_size_in = inputs[1];
-                let font_color_in = inputs[2];
-                let bg_color_in = inputs[3];
-                let opacity_in = inputs[4];
+                let text_color_in = inputs[2];
+                let text_opacity_in = inputs[3];
+                let bg_color_in = inputs[4];
+                let bg_opacity_in = inputs[5];
                 font_family_in.value = player_settings.fontFamily;
                 font_size_in.value = player_settings.fontSize;
-                font_color_in.value = player_settings.fontColor;
+                text_color_in.value = player_settings.fontColor;
+                text_opacity_in.value = player_settings.textOpacity;
                 bg_color_in.value = player_settings.bgColor;
-                opacity_in.value = player_settings.opacity;
+                bg_opacity_in.value = player_settings.bgOpacity;
                 btns[1].innerText = 'Save';
                 for (let i in inputs) {
                     inputs[i].disabled = false;
@@ -279,18 +283,20 @@ let PageManager = {
             btns[2].onclick = () => { PageManager.settingsPage.backFrom('player-settings-page') };
         },
         setToDefault() {
-            let defaults = { fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', opacity: '100' };
+            let defaults = { fontFamily: 'sans-serif', fontSize: '75', fontColor: '#ffffff', bgColor: '#000000', textOpacity: '100', bgOpacity: '80' };
             let inputs = document.querySelectorAll('#player-settings-page input');
             let font_family_in = inputs[0];
             let font_size_in = inputs[1];
-            let font_color_in = inputs[2];
-            let bg_color_in = inputs[3];
-            let opacity_in = inputs[4];
+            let text_color_in = inputs[2];
+            let text_opacity_in = inputs[3];
+            let bg_color_in = inputs[4];
+            let bg_opacity_in = inputs[5];
             font_family_in.value = defaults.fontFamily;
             font_size_in.value = defaults.fontSize;
-            font_color_in.value = defaults.fontColor;
+            text_color_in.value = defaults.fontColor;
+            text_opacity_in.value = defaults.textOpacity;
             bg_color_in.value = defaults.bgColor;
-            opacity_in.value = defaults.opacity;
+            bg_opacity_in.value = defaults.bgOpacity;
         },
         saveSettings() {
             let inputs = document.querySelectorAll('#player-settings-page input');
@@ -298,14 +304,15 @@ let PageManager = {
             let msg = document.querySelector('#player-settings-page div:last-child');
             let font_family_in = inputs[0];
             let font_size_in = inputs[1];
-            let font_color_in = inputs[2];
-            let bg_color_in = inputs[3];
-            let opacity_in = inputs[4];
+            let text_color_in = inputs[2];
+            let text_opacity_in = inputs[3];
+            let bg_color_in = inputs[4];
+            let bg_opacity_in = inputs[5];
             for (let i in inputs) {
                 if (inputs[i].value === '') return;
             }
             // update storage
-            let player_settings = { fontFamily: font_family_in.value, fontSize: font_size_in.value, fontColor: font_color_in.value, bgColor: bg_color_in.value, opacity: opacity_in.value };
+            let player_settings = { fontFamily: font_family_in.value, fontSize: font_size_in.value, fontColor: text_color_in.value, bgColor: bg_color_in.value, textOpacity: text_opacity_in.value, bgOpacity: bg_opacity_in.value };
             chrome.storage.sync.set({ playerSettings: JSON.stringify(player_settings) }, () => {
                 btns[1].innerText = 'Saved';
                 for (let i in inputs) {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "UoM Blackboard Enhancement",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Improve your experience of Blackboard of the University of Manchester.",
     "author": "RyanXin",
     "homepage_url": "https://www.ryanxin.cn/",


### PR DESCRIPTION
The font opacity will change with the background currently. So the text will be hard to read on dark background.

![2022-01-19_20-26-08](https://user-images.githubusercontent.com/14820835/150208327-72398793-2194-4525-a24a-617e75e976c2.png)

I'm trying to apply the opacity to the background only.
